### PR TITLE
Fix multiple commands produce PrivacyInfo.xcprivacy

### DIFF
--- a/IQKeyboardManager.podspec.json
+++ b/IQKeyboardManager.podspec.json
@@ -16,27 +16,24 @@
     "ios": "11.0"
   },
   "source_files": "IQKeyboardManager/**/*.{h,m}",
-  "resources": "IQKeyboardManager/PrivacyInfo.xcprivacy",
+  "resource_bundles": {
+    "IQKeyboardManager": "IQKeyboardManager/PrivacyInfo.xcprivacy"
+  },
   "public_header_files": [
-      "IQKeyboardManager/IQKeyboardManager.h",
-      "IQKeyboardManager/IQKeyboardReturnKeyHandler.h",
-      "IQKeyboardManager/Categories/IQUIScrollView+Additions.h",
-      "IQKeyboardManager/Categories/IQUITextFieldView+Additions.h",
-      "IQKeyboardManager/Categories/IQUIView+Hierarchy.h",
-      "IQKeyboardManager/Categories/IQUIViewController+Additions.h",
-      "IQKeyboardManager/Constants/IQKeyboardManagerConstants.h",
-      "IQKeyboardManager/IQTextView/IQTextView.h",
-      "IQKeyboardManager/IQToolbar/IQBarButtonItem.h",
-      "IQKeyboardManager/IQToolbar/IQPreviousNextView.h",
-      "IQKeyboardManager/IQToolbar/IQTitleBarButtonItem.h",
-      "IQKeyboardManager/IQToolbar/IQToolbar.h",
-      "IQKeyboardManager/IQToolbar/IQUIView+IQKeyboardToolbar.h"
+    "IQKeyboardManager/IQKeyboardManager.h",
+    "IQKeyboardManager/IQKeyboardReturnKeyHandler.h",
+    "IQKeyboardManager/Categories/IQUIScrollView+Additions.h",
+    "IQKeyboardManager/Categories/IQUITextFieldView+Additions.h",
+    "IQKeyboardManager/Categories/IQUIView+Hierarchy.h",
+    "IQKeyboardManager/Categories/IQUIViewController+Additions.h",
+    "IQKeyboardManager/Constants/IQKeyboardManagerConstants.h",
+    "IQKeyboardManager/IQTextView/IQTextView.h",
+    "IQKeyboardManager/IQToolbar/IQBarButtonItem.h",
+    "IQKeyboardManager/IQToolbar/IQPreviousNextView.h",
+    "IQKeyboardManager/IQToolbar/IQTitleBarButtonItem.h",
+    "IQKeyboardManager/IQToolbar/IQToolbar.h",
+    "IQKeyboardManager/IQToolbar/IQUIView+IQKeyboardToolbar.h"
   ],
-  "frameworks": [
-    "UIKit",
-    "Foundation",
-    "CoreGraphics",
-    "QuartzCore"
-  ],
+  "frameworks": ["UIKit", "Foundation", "CoreGraphics", "QuartzCore"],
   "requires_arc": true
 }

--- a/IQKeyboardManagerSwift.podspec.json
+++ b/IQKeyboardManagerSwift.podspec.json
@@ -28,17 +28,14 @@
     "5.8",
     "5.9"
   ],
-  "source_files": "IQKeyboardManagerSwift/**/*.{swift, xcprivacy}",
-  "resources": "IQKeyboardManagerSwift/PrivacyInfo.xcprivacy",
-  "frameworks": [
-    "UIKit",
-    "Foundation",
-    "CoreGraphics",
-    "QuartzCore"
-  ],
+  "source_files": "IQKeyboardManagerSwift/**/*.{swift}",
+  "resource_bundles": {
+    "IQKeyboardManagerSwift": "IQKeyboardManagerSwift/PrivacyInfo.xcprivacy"
+  },
+  "frameworks": ["UIKit", "Foundation", "CoreGraphics", "QuartzCore"],
   "libraries": "swiftCoreGraphics",
   "xcconfig": {
-      "LIBRARY_SEARCH_PATHS": "$(SDKROOT)/usr/lib/swift"
+    "LIBRARY_SEARCH_PATHS": "$(SDKROOT)/usr/lib/swift"
   },
   "requires_arc": true
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,17 +1,22 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "IQKeyboardManagerSwift",
+    platforms: [
+        .iOS(.v13)
+    ],
     products: [
-       .library(name: "IQKeyboardManagerSwift", targets: ["IQKeyboardManagerSwift"])
-   ],
-   targets: [
-       .target(
-           name: "IQKeyboardManagerSwift",
-           path: "IQKeyboardManagerSwift"
-       )
-   ]
+        .library(name: "IQKeyboardManagerSwift",
+                 targets: ["IQKeyboardManagerSwift"])
+    ],
+    targets: [
+        .target(
+            name: "IQKeyboardManagerSwift",
+            path: "IQKeyboardManagerSwift",
+            resources: [.copy("PrivacyInfo.xcprivacy")]
+        )
+    ]
 )


### PR DESCRIPTION
# Description

Fixes a compilation error when a project contains the file `PrivacyInfo.xcprivacy`. 

> Multiple commands produce '/Users/SomeDev/Library/Developer/Xcode/DerivedData/YourProject/Build/Products/Debug-iphonesimulator/YourProject/PrivacyInfo.xcprivacy'